### PR TITLE
Result table tabulate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ examples/*.sav
 *htmlcov/*
 .eggs
 lmfit/version.py
+.venv/

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -28,7 +28,7 @@ def getfloat_attr(obj, attr, length=11):
     if isinstance(val, int):
         return f'{val}'
     if isinstance(val, float):
-        return f"{val:.4f}"
+        return gformat(val, length=length).strip()
     return repr(val)
 
 

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -4,6 +4,8 @@ from math import log10
 import re
 
 import numpy as np
+from tabulate import tabulate
+from uncertainties import ufloat
 
 try:
     import numdifftools  # noqa: F401
@@ -26,7 +28,7 @@ def getfloat_attr(obj, attr, length=11):
     if isinstance(val, int):
         return f'{val}'
     if isinstance(val, float):
-        return gformat(val, length=length).strip()
+        return f"{val:.4f}"
     return repr(val)
 
 
@@ -79,6 +81,13 @@ def gformat(val, length=11):
         if expon > 0:
             prec -= expon
     return f'{val:{length}.{prec}{form}}'
+
+
+def indent_string_block(string_block, depth=4):
+    indent = " "*depth
+    string_block = f"{indent}{string_block}"
+    string_block = string_block.replace("\n", f"\n{indent}")
+    return string_block
 
 
 def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
@@ -139,16 +148,23 @@ def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
     namelen = max(len(n) for n in parnames)
     if result is not None:
         add("[[Fit Statistics]]")
-        add(f"    # fitting method   = {result.method}")
-        add(f"    # function evals   = {getfloat_attr(result, 'nfev')}")
-        add(f"    # data points      = {getfloat_attr(result, 'ndata')}")
-        add(f"    # variables        = {getfloat_attr(result, 'nvarys')}")
-        add(f"    chi-square         = {getfloat_attr(result, 'chisqr')}")
-        add(f"    reduced chi-square = {getfloat_attr(result, 'redchi')}")
-        add(f"    Akaike info crit   = {getfloat_attr(result, 'aic')}")
-        add(f"    Bayesian info crit = {getfloat_attr(result, 'bic')}")
+        fit_stats_data = [
+            ["# fitting method", result.method],
+            ["# function evals", getfloat_attr(result, 'nfev')],
+            ["# data points", getfloat_attr(result, 'ndata')],
+            ["# variables", getfloat_attr(result, 'nvarys')],
+            ["chi-square", getfloat_attr(result, 'chisqr')],
+            ["reduced chi-square", getfloat_attr(result, 'redchi')],
+            ["Akaike info crit", getfloat_attr(result, 'aic')],
+            ["Bayesian info crit", getfloat_attr(result, 'bic')],
+        ]
         if hasattr(result, 'rsquared'):
-            add(f"    R-squared          = {getfloat_attr(result, 'rsquared')}")
+            fit_stats_data.append(["R-squared", getfloat_attr(result, 'rsquared')])
+
+        fit_stats_table = tabulate(fit_stats_data, disable_numparse=True)
+        fit_stats_table = indent_string_block(fit_stats_table)
+        add(fit_stats_table)
+
         if not result.errorbars:
             add("##  Warning: uncertainties could not be estimated:")
             if result.method in ('leastsq', 'least_squares') or HAS_NUMDIFFTOOLS:
@@ -167,39 +183,65 @@ def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
                 add("    `pip install numdifftools` for lmfit to estimate uncertainties")
                 add("    with this fitting method.")
 
+    var_data = []
     add("[[Variables]]")
     for name in parnames:
+        single_var_data = {
+            "Name": None,
+            "Value": None,
+            "Percent Uncertainty": None,
+            "Constraint": None,
+            "Init Val": None,
+            "Model Val": None,
+        }
         par = params[name]
-        space = ' '*(namelen-len(name))
-        nout = f"{name}:{space}"
-        inval = '(init = ?)'
+        single_var_data["Name"] = name
+
         if par.init_value is not None:
-            inval = f'(init = {par.init_value:.7g})'
+            single_var_data["Init Val"] = f"{par.init_value:.7g}"
+        else:
+            single_var_data["Init Val"] = ""
+
         if modelpars is not None and name in modelpars:
-            inval = f'{inval}, model_value = {modelpars[name].value:.7g}'
-        try:
-            sval = gformat(par.value)
-        except (TypeError, ValueError):
-            sval = ' Non Numeric Value?'
-        if par.stderr is not None:
-            serr = gformat(par.stderr)
-            try:
-                spercent = f'({abs(par.stderr/par.value):.2%})'
-            except ZeroDivisionError:
-                spercent = ''
-            sval = f'{sval} +/-{serr} {spercent}'
+            single_var_data["Model Val"] = f"{modelpars[name].value:.7g}"
+        else:
+            single_var_data["Model Val"] = ""
+
+        val = par.value
+        if not isinstance(val, (int, float)):
+            single_var_data["Value"] = "Non Numeric Value?"
+        else:
+            stderr = par.stderr
+            if stderr is not None:
+                single_var_data["Value"] = f"{ufloat(val, stderr):.2ue}"
+                try:
+                    single_var_data[
+                        "Percent Uncertainty"] = f'{abs(par.stderr / par.value):.2%}'
+                except ZeroDivisionError:
+                    single_var_data["Percent Uncertainty"] = ""
+            else:
+                single_var_data["Value"] = f"{val:.7g}"
+                single_var_data["Percent Uncertainty"] = ""
 
         if par.vary:
-            add(f"    {nout} {sval} {inval}")
+            single_var_data["Constraint"] = "Vary"
         elif par.expr is not None:
-            add(f"    {nout} {sval} == '{par.expr}'")
+            single_var_data["Constraint"] = par.expr
         else:
-            add(f"    {nout} {par.value: .7g} (fixed)")
+            single_var_data["Constraint"] = "Fixed"
+
+        var_data.append(single_var_data)
+
+    var_table = tabulate(var_data, headers="keys", tablefmt="simple", numalign="center",
+                         stralign="center", disable_numparse=True)
+    var_table = indent_string_block(var_table)
+    add(var_table)
 
     if show_correl and correl_mode.startswith('tab'):
         add('[[Correlations]] ')
-        for line in correl_table(params).split('\n'):
-            buff.append('  %s' % line)
+        correl_table_str = correl_table(params)
+        correl_table_str = indent_string_block(correl_table_str)
+        add(correl_table_str)
     elif show_correl:
         correls = {}
         for i, name in enumerate(parnames):
@@ -313,39 +355,27 @@ def fitreport_html_table(result, show_correl=True, min_correl=0.1):
 
 
 def correl_table(params):
-    """Return a printable correlation table for a Parameters object."""
     varnames = [vname for vname in params if params[vname].vary]
-    nwid = max(8, max([len(vname) for vname in varnames])) + 1
 
-    def sfmt(a):
-        return f" {a:{nwid}s}"
+    correl_data = []
 
-    def ffmt(a):
-        return sfmt(f"{a:+.4f}")
-
-    title = ['', sfmt('Variable')]
-    title.extend([sfmt(vname) for vname in varnames])
-
-    title = '|'.join(title) + '|'
-    bar = [''] + ['-'*(nwid+1) for i in range(len(varnames)+1)] + ['']
-    bar = '+'.join(bar)
-
-    buff = [bar, title, bar]
-
-    for vname, par in params.items():
-        if not par.vary:
-            continue
-        line = ['', sfmt(vname)]
+    for vname in varnames:
+        var_data_dict = dict.fromkeys([""] + varnames)
+        var_data_dict[""] = vname
+        par = params[vname]
         for vother in varnames:
+
             if vother == vname:
-                line.append(ffmt(1))
+                var_data_dict[vother] = f"{1.0:+.4f}"
             elif vother in par.correl:
-                line.append(ffmt(par.correl[vother]))
+                var_data_dict[vother] = f"{par.correl[vother]:+.4f}"
             else:
-                line.append('unknown')
-        buff.append('|'.join(line) + '|')
-    buff.append(bar)
-    return '\n'.join(buff)
+                var_data_dict[vother] = "unknown"
+        correl_data.append(var_data_dict)
+
+    correl_table_str = tabulate(correl_data, headers="keys", tablefmt="simple_grid",
+                                disable_numparse=True)
+    return correl_table_str
 
 
 def params_html_table(params):


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
In this PR I demonstrate how the report table code can be updated using `tabulate`. The major advantage of `tabulate` is that the person writing the code to present the table doesn't need to think about whitespace at all*. They simply make a data array acceptable to `tabulate` (e.g list of lists or list of dicts) and pass it into the `tabulate` function with nice user options available.

For demonstration purposes I drop usage of `gformat` to show how the table would look without strict lining up of the left- and right-most decimal places across rows. I also use `uncertainties` `ufloat` to format the value/uncertainty pairs describing the variable values. 

`printfuncs.py` was not totally reworked. Only enough code was reworked to affect the `example_fit_with_bounds.py` example script.

*Strictly speaking I did need to include an `indent_string_block` function to allow me to have the tables be "nested" under their respective heading. It would be nice if `tabulate` had a "left pad" feature that did this internally.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ ] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [ ] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?

